### PR TITLE
fix: release audio session when app is backgrounded

### DIFF
--- a/android/src/main/kotlin/org/lichess/sound_effect/SoundEffectPlugin.kt
+++ b/android/src/main/kotlin/org/lichess/sound_effect/SoundEffectPlugin.kt
@@ -3,14 +3,22 @@ package org.lichess.sound_effect
 import android.media.AudioAttributes
 import android.media.SoundPool
 
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.StandardMethodCodec
 
-class SoundEffectPlugin: FlutterPlugin, MethodCallHandler, SoundPool.OnLoadCompleteListener {
+class SoundEffectPlugin: FlutterPlugin, MethodCallHandler, SoundPool.OnLoadCompleteListener,
+    ActivityAware, DefaultLifecycleObserver {
   companion object {
     private const val CHANNEL_NAME = "org.lichess/sound_effect"
   }
@@ -19,6 +27,7 @@ class SoundEffectPlugin: FlutterPlugin, MethodCallHandler, SoundPool.OnLoadCompl
   private lateinit var binding: FlutterPlugin.FlutterPluginBinding
 
   private var soundPool: SoundPool? = null
+  private var lifecycle: Lifecycle? = null
 
   // Map of audio IDs to SoundPool sample IDs
   private val audioMap = HashMap<String, Int>()
@@ -122,5 +131,37 @@ class SoundEffectPlugin: FlutterPlugin, MethodCallHandler, SoundPool.OnLoadCompl
     } else {
       channel.invokeMethod("onLoadError", hashMapOf("soundId" to audioId, "error" to status))
     }
+  }
+
+  // ActivityAware
+
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding)
+    lifecycle?.addObserver(this)
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+    lifecycle?.removeObserver(this)
+    lifecycle = null
+  }
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding)
+    lifecycle?.addObserver(this)
+  }
+
+  override fun onDetachedFromActivity() {
+    lifecycle?.removeObserver(this)
+    lifecycle = null
+  }
+
+  // DefaultLifecycleObserver — pause/resume audio when app is backgrounded/foregrounded
+
+  override fun onStop(owner: LifecycleOwner) {
+    soundPool?.autoPause()
+  }
+
+  override fun onStart(owner: LifecycleOwner) {
+    soundPool?.autoResume()
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -83,6 +83,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.33"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -134,18 +142,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -250,10 +258,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -279,5 +287,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.8.0-70.0.dev <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/ios/Classes/SoundEffectPlugin.swift
+++ b/ios/Classes/SoundEffectPlugin.swift
@@ -7,6 +7,7 @@ public class SoundEffectPlugin: NSObject, FlutterPlugin {
   private var maxConcurrentSounds = 1
   private var audioMap = [String : [AVAudioPlayer]]()
   private var registrar: FlutterPluginRegistrar? = nil
+  private var isSessionActive = false
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let taskQueue = registrar.messenger().makeBackgroundTaskQueue?()
@@ -18,6 +19,32 @@ public class SoundEffectPlugin: NSObject, FlutterPlugin {
     let instance = SoundEffectPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
     instance.registrar = registrar
+
+    NotificationCenter.default.addObserver(
+        instance,
+        selector: #selector(appDidEnterBackground),
+        name: UIApplication.didEnterBackgroundNotification,
+        object: nil)
+    NotificationCenter.default.addObserver(
+        instance,
+        selector: #selector(appWillEnterForeground),
+        name: UIApplication.willEnterForegroundNotification,
+        object: nil)
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  @objc private func appDidEnterBackground() {
+    guard isSessionActive else { return }
+    try? AVAudioSession.sharedInstance().setActive(false,
+        options: .notifyOthersOnDeactivation)
+  }
+
+  @objc private func appWillEnterForeground() {
+    guard isSessionActive else { return }
+    try? AVAudioSession.sharedInstance().setActive(true)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -32,6 +59,7 @@ public class SoundEffectPlugin: NSObject, FlutterPlugin {
                 options: [])
             try session.setPreferredIOBufferDuration(0.005)
             try session.setActive(true)
+            isSessionActive = true
         } catch let error as NSError {
             print("Failed to set the audio session: \(error.localizedDescription)")
         }
@@ -106,6 +134,9 @@ public class SoundEffectPlugin: NSObject, FlutterPlugin {
         result(nil)
     case "release":
         audioMap.removeAll()
+        isSessionActive = false
+        try? AVAudioSession.sharedInstance().setActive(false,
+            options: .notifyOthersOnDeactivation)
         result(nil)
     default:
         result(FlutterMethodNotImplemented)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_plugin_android_lifecycle: ^2.0.0
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

Fixes lichess-org/mobile#2768

The SoundPool (Android) / AVAudioSession (iOS) stays active when the app is backgrounded, holding an AudioMix wakelock indefinitely and causing severe battery drain.

### Android
- Implement `ActivityAware` + `DefaultLifecycleObserver` via `FlutterLifecycleAdapter`
- Call `SoundPool.autoPause()` on `onStop` and `SoundPool.autoResume()` on `onStart`
- This pauses all active streams without destroying loaded sounds, so no re-initialization is needed on resume

### iOS
- Observe `didEnterBackgroundNotification` / `willEnterForegroundNotification` to toggle `AVAudioSession.setActive()`
- Also deactivate the session on `release()`
- Track session state with `isSessionActive` flag to avoid toggling before init or after release

## Test plan

Tested on a real Android device (Samsung SM S911B):
- [x] Play sound, background app → AudioMix wakelock is released (verified via `adb shell dumpsys power`)
- [x] Bring app back to foreground → sound plays normally without re-initialization
- [x] Before fix: AudioMix wakelock held indefinitely after backgrounding

Tested on iOS simulator (iPad Pro):
- [x] App compiles and runs
- [x] Play sound, background, foreground → sound still works, no crashes